### PR TITLE
Add top coalition info

### DIFF
--- a/BatFiKit/Sources/AppShared/Formatters.swift
+++ b/BatFiKit/Sources/AppShared/Formatters.swift
@@ -31,3 +31,11 @@ public let percentageFormatter: NumberFormatter = {
     formatter.maximumFractionDigits = 0
     return formatter
 }()
+
+public let energyImpactFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 2
+    formatter.maximumFractionDigits = 2
+    return formatter
+}()

--- a/BatFiKit/Sources/AppShared/TopCoalitionInfo.swift
+++ b/BatFiKit/Sources/AppShared/TopCoalitionInfo.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+public struct TopCoalitionInfo: Equatable {
+    public let topCoalitions: [Coalition]
+    
+    public init(topCoalitions: [Coalition]) {
+        self.topCoalitions = topCoalitions
+    }
+}
+
+public struct Coalition: Equatable {
+    public let bundleIdentifier: String
+    public let energyImpact: Double
+    public let icon: NSImage?
+    public let displayName: String?
+    
+    public init(bundleIdentifier: String, energyImpact: Double, icon: NSImage?, displayName: String?) {
+        self.bundleIdentifier = bundleIdentifier
+        self.energyImpact = energyImpact
+        self.icon = icon
+        self.displayName = displayName
+    }
+}

--- a/BatFiKit/Sources/BatteryInfo/BatteryInfoView.swift
+++ b/BatFiKit/Sources/BatteryInfo/BatteryInfoView.swift
@@ -5,11 +5,14 @@
 //  Created by Adam on 20/04/2023.
 //
 
+import Defaults
 import SwiftUI
 import AppShared
 import L10n
 
 public struct BatteryInfoView: View {
+    @Default(.showHighEnergyImpactProcesses) private var showHighEnergyImpactProcesses
+    
     @StateObject private var model = Model()
 
     public init() { }
@@ -58,6 +61,10 @@ public struct BatteryInfoView: View {
                         )
                     }
                     .frame(maxWidth: .infinity)
+                    if let topCoalitionInfo = model.topCoalitionInfo, showHighEnergyImpactProcesses {
+                        SeparatorView()
+                        BatteryTopCoalitionInfo(topCoalitionInfo: topCoalitionInfo)
+                    }
                 }
                 .onDisappear {
                     model.cancelObserving()
@@ -124,6 +131,49 @@ struct BatteryAdditionalInfo<Label: View>: View {
             }
             .foregroundColor(.secondary)
             .font(.callout)
+        }
+    }
+}
+
+struct BatteryTopCoalitionInfo: View {
+    let topCoalitionInfo: TopCoalitionInfo
+    
+    init(topCoalitionInfo: TopCoalitionInfo) {
+        self.topCoalitionInfo = topCoalitionInfo
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if topCoalitionInfo.topCoalitions.count > 0 {
+                Text(L10n.BatteryInfo.Label.TopCoalition.some)
+                    .bold()
+                ForEach(topCoalitionInfo.topCoalitions, id: \.bundleIdentifier) { coalition in
+                    BatteryTopCoalitionInfoItem(coalition: coalition)
+                }
+            } else {
+                Text(L10n.BatteryInfo.Label.TopCoalition.none)
+            }
+        }
+        .foregroundColor(.secondary)
+        .font(.callout)
+    }
+}
+
+struct BatteryTopCoalitionInfoItem: View {
+    let coalition: Coalition
+    
+    init(coalition: Coalition) {
+        self.coalition = coalition
+    }
+    
+    var body: some View {
+        HStack {
+            Image(nsImage: coalition.icon ?? NSWorkspace.shared.icon(for: .applicationBundle))
+                .resizable()
+                .frame(width: 24, height: 24)
+            Text(coalition.displayName ?? coalition.bundleIdentifier)
+            Spacer()
+            Text(energyImpactFormatter.string(from: NSNumber(floatLiteral: coalition.energyImpact))!)
         }
     }
 }

--- a/BatFiKit/Sources/Clients/SystemStatsClient.swift
+++ b/BatFiKit/Sources/Clients/SystemStatsClient.swift
@@ -1,0 +1,19 @@
+import AppShared
+import Dependencies
+
+public struct SystemStatsClient: TestDependencyKey {
+    public var topCoalitionInfoChanges: () -> AsyncStream<TopCoalitionInfo>
+    
+    public init(topCoalitionInfoChanges: @escaping () -> AsyncStream<TopCoalitionInfo>) {
+        self.topCoalitionInfoChanges = topCoalitionInfoChanges
+    }
+    
+    public static var testValue: SystemStatsClient = unimplemented()
+}
+
+extension DependencyValues {
+    public var systemStatsClient: SystemStatsClient {
+        get { self[SystemStatsClient.self] }
+        set { self[SystemStatsClient.self] = newValue }
+    }
+}

--- a/BatFiKit/Sources/ClientsLive/SystemStatsClient.swift
+++ b/BatFiKit/Sources/ClientsLive/SystemStatsClient.swift
@@ -1,0 +1,75 @@
+import AppKit
+import AppShared
+import Clients
+import Defaults
+import Dependencies
+import Shared
+
+extension SystemStatsClient: DependencyKey {
+    public static var liveValue: SystemStatsClient {
+        @Sendable func topCoalitionInfo() -> TopCoalitionInfo? {
+            guard let systemstats_get_top_coalitions = Private.systemstats_get_top_coalitions else {
+                return nil
+            }
+            let threshold = Defaults[.highEnergyImpactProcessesThreshold]
+            let duration = Defaults[.highEnergyImpactProcessesDuration] * 60
+            let capacity = Defaults[.highEnergyImpactProcessesCapacity]
+            guard
+                let topCoalitionDictionary = systemstats_get_top_coalitions(duration, 10000).takeUnretainedValue() as? [String: Any],
+                let bundleIdentifiers = topCoalitionDictionary["bundle_identifiers"] as? [String],
+                let energyImpacts = topCoalitionDictionary["energy_impacts"] as? [Double],
+                bundleIdentifiers.count == energyImpacts.count
+            else {
+                return nil
+            }
+            var topCoalitions = [Coalition]()
+            for (index, bundleIdentifier) in bundleIdentifiers.enumerated() {
+                guard topCoalitions.count < capacity else {
+                    break
+                }
+                let energyImpact = energyImpacts[index] / Double(duration)
+                guard energyImpact >= Double(threshold) else {
+                    break
+                }
+                let bundleIdentifier = bundleIdentifier == "REDACTED" ? "<private>" : bundleIdentifier
+                var icon: NSImage?
+                var displayName: String?
+                if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
+                    icon = NSWorkspace.shared.icon(forFile: url.path(percentEncoded: false))
+                    if let bundle = Bundle(url: url) {
+                        displayName = (
+                            bundle.localizedInfoDictionary?["CFBundleDisplayName"] as? String ??
+                            bundle.infoDictionary?["CFBundleDisplayName"] as? String ??
+                            bundle.localizedInfoDictionary?[kCFBundleNameKey as String] as? String ??
+                            bundle.infoDictionary?[kCFBundleNameKey as String] as? String
+                        )
+                    }
+                }
+                let coalition = Coalition(bundleIdentifier: bundleIdentifier, energyImpact: energyImpact, icon: icon, displayName: displayName)
+                topCoalitions.append(coalition)
+            }
+            return TopCoalitionInfo(topCoalitions: topCoalitions)
+        }
+        
+        let client = Self(
+            topCoalitionInfoChanges: {
+                AsyncStream { continuation in
+                    let task = Task {
+                        var prevInfo: TopCoalitionInfo?
+                        while !Task.isCancelled {
+                            if let info = topCoalitionInfo(), info != prevInfo {
+                                continuation.yield(info)
+                                prevInfo = info
+                            }
+                            try await Task.sleep(for: .seconds(1))
+                        }
+                    }
+                    continuation.onTermination = { _ in
+                        task.cancel()
+                    }
+                }
+            }
+        )
+        return client
+    }
+}

--- a/BatFiKit/Sources/DefaultsKeys/Defaults.swift
+++ b/BatFiKit/Sources/DefaultsKeys/Defaults.swift
@@ -30,6 +30,10 @@ extension Defaults.Keys {
     public static let showGreenLightMagSafeWhenInhibiting = Key<Bool>("showGreenLightMagSafeWhenInhibiting", default: false)
     public static let turnOnInhibitingChargingWhenGoingToSleep = Key<Bool>("turnOnInhibitingChargingWhenGoingToSleep", default: false)
     public static let downloadBetaVersion = Key<Bool>("downloadBetaVersion", default: false)
+    public static let showHighEnergyImpactProcesses = Key<Bool>("showHighEnergyImpactProcesses", default: false)
+    public static let highEnergyImpactProcessesThreshold = Key<Int>("highEnergyImpactProcessesThreshold", default: 500)
+    public static let highEnergyImpactProcessesDuration = Key<Int>("highEnergyImpactProcessesDuration", default: 2)
+    public static let highEnergyImpactProcessesCapacity = Key<Int>("highEnergyImpactProcessesCapacity", default: 5)
 
 
     // notifications

--- a/BatFiKit/Sources/L10n/Strings.swift
+++ b/BatFiKit/Sources/L10n/Strings.swift
@@ -88,6 +88,12 @@ public enum L10n {
           public static let timeToCharge = L10n.tr("Localizable", "battery_info.label.main.time.time_to_charge", fallback: "Time to Charge")
         }
       }
+      public enum TopCoalition {
+        /// No processes with high energy impact
+        public static let `none` = L10n.tr("Localizable", "battery_info.label.top_coalition.none", fallback: "No processes with high energy impact")
+        /// Processes with high energy impact
+        public static let some = L10n.tr("Localizable", "battery_info.label.top_coalition.some", fallback: "Processes with high energy impact")
+      }
     }
   }
   public enum Menu {
@@ -217,6 +223,8 @@ public enum L10n {
         public static let charging = L10n.tr("Localizable", "settings.accessibility.title.charging", fallback: "Charging pane")
         /// General pane
         public static let general = L10n.tr("Localizable", "settings.accessibility.title.general", fallback: "General pane")
+        /// Menu pane
+        public static let menu = L10n.tr("Localizable", "settings.accessibility.title.menu", fallback: "Menu pane")
         /// Notifications pane
         public static let notifications = L10n.tr("Localizable", "settings.accessibility.title.notifications", fallback: "Notifications pane")
       }
@@ -247,6 +255,8 @@ public enum L10n {
         public static let disableAutomaticSleep = L10n.tr("Localizable", "settings.button.label.disable_automatic_sleep", fallback: "Delay automatic sleep when charging and the limit's not reached")
         /// Discharge battery when charged over limit
         public static let dischargeBatterWhenOvercharged = L10n.tr("Localizable", "settings.button.label.discharge_batter_when_overcharged", fallback: "Discharge battery when charged over limit")
+        /// Show
+        public static let highEnergyImpactProcessesShow = L10n.tr("Localizable", "settings.button.label.high_energy_impact_processes_show", fallback: "Show")
         /// Open at login
         public static let launchAtLogin = L10n.tr("Localizable", "settings.button.label.launch_at_login", fallback: "Open at login")
         /// Use the green light on the MagSafe when charging is paused
@@ -274,6 +284,18 @@ public enum L10n {
       public static let chargingRecommendationPart1 = L10n.tr("Localizable", "settings.label.charging_recommendation_part1", fallback: "80%% is the recommended value for a day-to-day usage.")
       /// You can manually override this setting by using the "Charge to 100%%" command from the menu.
       public static let chargingRecommendationPart2 = L10n.tr("Localizable", "settings.label.charging_recommendation_part2", fallback: "You can manually override this setting by using the \"Charge to 100%%\" command from the menu.")
+      /// Capacity:
+      public static let highEnergyImpactProcessesCapacity = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_capacity", fallback: "Capacity:")
+      /// processes
+      public static let highEnergyImpactProcessesCapacityUnit = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_capacity_unit", fallback: "processes")
+      /// Duration:
+      public static let highEnergyImpactProcessesDuration = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_duration", fallback: "Duration:")
+      /// minutes
+      public static let highEnergyImpactProcessesDurationUnit = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_duration_unit", fallback: "minutes")
+      /// Threshold:
+      public static let highEnergyImpactProcessesThreshold = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_threshold", fallback: "Threshold:")
+      /// energy impact of
+      public static let highEnergyImpactProcessesThresholdUnit = L10n.tr("Localizable", "settings.label.high_energy_impact_processes_threshold_unit", fallback: "energy impact of")
     }
     public enum Section {
       /// Advanced
@@ -282,6 +304,8 @@ public enum L10n {
       public static let alerts = L10n.tr("Localizable", "settings.section.alerts", fallback: "Alerts")
       /// General
       public static let general = L10n.tr("Localizable", "settings.section.general", fallback: "General")
+      /// High energy impact processes
+      public static let highEnergyImpactProcesses = L10n.tr("Localizable", "settings.section.high_energy_impact_processes", fallback: "High energy impact processes")
       /// MagSafe
       public static let magSafe = L10n.tr("Localizable", "settings.section.magSafe", fallback: "MagSafe")
       /// Notifications
@@ -305,6 +329,8 @@ public enum L10n {
         public static let charging = L10n.tr("Localizable", "settings.tab.title.charging", fallback: "Charging")
         /// General
         public static let general = L10n.tr("Localizable", "settings.tab.title.general", fallback: "General")
+        /// Menu
+        public static let menu = L10n.tr("Localizable", "settings.tab.title.menu", fallback: "Menu")
         /// Notifications
         public static let notifications = L10n.tr("Localizable", "settings.tab.title.notifications", fallback: "Notifications")
       }

--- a/BatFiKit/Sources/L10n/en.lproj/Localizable.strings
+++ b/BatFiKit/Sources/L10n/en.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 "battery_info.label.main.time.calculating" = "Calculating…";
 "battery_info.label.main.time.time_left" = "Time Left";
 "battery_info.label.main.time.time_to_charge" = "Time to Charge";
+"battery_info.label.top_coalition.some" = "Processes with high energy impact";
+"battery_info.label.top_coalition.none" = "No processes with high energy impact";
 "menu.label.batfi" = "BatFi…";
 "menu.label.charge_to_hundred" = "Charge to 100%%";
 "menu.label.check_for_updates" = "Check for Updates…";
@@ -62,6 +64,7 @@
 "settings.accessibility.title.charging" = "Charging pane";
 "settings.accessibility.title.general" = "General pane";
 "settings.accessibility.title.notifications" = "Notifications pane";
+"settings.accessibility.title.menu" = "Menu pane";
 "settings.button.description.lid_must_be_opened" = "Works only with the lid opened.";
 "settings.button.label.automatically_check_updates" = "Automatically check for updates";
 "settings.button.label.automatically_download_updates" = "Automatically download updates";
@@ -79,11 +82,18 @@
 "settings.button.label.pause_charging_on_sleep" = "Automatically pause charging when the Mac goes to sleep";
 "settings.button.label.show_alerts_when_optimized_charging_is_engaged" = "Show alert when the optimized battery charging is engaged";
 "settings.button.label.turn_off_charging_when_battery_is_hot" = "Automatically turn off charging when the battery gets hot";
+"settings.button.label.high_energy_impact_processes_show" = "Show";
 "settings.button.tooltip.disable_automatic_sleep" = "The app will delay sleep so the computer charge up to the limit and then it'll inhibit charging and put the Mac to sleep";
 "settings.button.tooltip.discharge_batter_when_overcharged" = "When Macbook's lid is opened, the app can discharge battery until it will reach the limit";
 "settings.button.tooltip.turn_off_charging_when_battery_is_hot" = "Turns off charging when the battery is 35°C or more.";
 "settings.label.charging_recommendation_part1" = "80%% is the recommended value for a day-to-day usage.";
 "settings.label.charging_recommendation_part2" = "You can manually override this setting by using the \"Charge to 100%%\" command from the menu.";
+"settings.label.high_energy_impact_processes_threshold" = "Threshold:";
+"settings.label.high_energy_impact_processes_threshold_unit" = "energy impact of";
+"settings.label.high_energy_impact_processes_duration" = "Duration:";
+"settings.label.high_energy_impact_processes_duration_unit" = "minutes";
+"settings.label.high_energy_impact_processes_capacity" = "Capacity:";
+"settings.label.high_energy_impact_processes_capacity_unit" = "processes";
 "settings.section.advanced" = "Advanced";
 "settings.section.alerts" = "Alerts";
 "settings.section.general" = "General";
@@ -91,8 +101,10 @@
 "settings.section.notifications" = "Notifications";
 "settings.section.status_icon" = "Status icon";
 "settings.section.updates" = "Updates";
+"settings.section.high_energy_impact_processes" = "High energy impact processes";
 "settings.slider.label.turn_off_charging_at" = "Turn off charging when battery will reach %@";
 "settings.tab.title.charging" = "Charging";
 "settings.tab.title.general" = "General";
 "settings.tab.title.notifications" = "Notifications";
+"settings.tab.title.menu" = "Menu";
 "texterify_timestamp" = "2023-07-17T22:40:34Z";

--- a/BatFiKit/Sources/Settings/MenuView.swift
+++ b/BatFiKit/Sources/Settings/MenuView.swift
@@ -1,0 +1,57 @@
+import Defaults
+import L10n
+import SettingsKit
+import SwiftUI
+
+struct MenuView: View {
+    @Default(.showHighEnergyImpactProcesses)      private var showHighEnergyImpactProcesses
+    @Default(.highEnergyImpactProcessesThreshold) private var highEnergyImpactProcessesThreshold
+    @Default(.highEnergyImpactProcessesDuration)  private var highEnergyImpactProcessesDuration
+    @Default(.highEnergyImpactProcessesCapacity)  private var highEnergyImpactProcessesCapacity
+    
+    var body: some View {
+        let l10n = L10n.Settings.self
+        Container(contentWidth: settingsContentWidth) {
+            Section(title: l10n.Section.highEnergyImpactProcesses) {
+                Toggle(l10n.Button.Label.highEnergyImpactProcessesShow, isOn: $showHighEnergyImpactProcesses)
+                HStack {
+                    Text(l10n.Label.highEnergyImpactProcessesThreshold)
+                    Text(l10n.Label.highEnergyImpactProcessesThresholdUnit)
+                    TextField("", value: $highEnergyImpactProcessesThreshold, format: .number)
+                        .multilineTextAlignment(.center)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 60)
+                }
+                HStack {
+                    Text(l10n.Label.highEnergyImpactProcessesDuration)
+                    TextField("", value: $highEnergyImpactProcessesDuration, format: .number)
+                        .multilineTextAlignment(.center)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 50)
+                    Text(l10n.Label.highEnergyImpactProcessesDurationUnit)
+                }
+                HStack {
+                    Text(l10n.Label.highEnergyImpactProcessesCapacity)
+                    TextField("", value: $highEnergyImpactProcessesCapacity, format: .number)
+                        .multilineTextAlignment(.center)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 45)
+                    Text(l10n.Label.highEnergyImpactProcessesCapacityUnit)
+                }
+            }
+        }
+    }
+    
+    static let pane: Pane<Self> = {
+        Pane(
+            identifier: NSToolbarItem.Identifier("Menu"),
+            title: L10n.Settings.Tab.Title.menu,
+            toolbarIcon: NSImage(
+                systemSymbolName: "line.3.horizontal.circle.fill",
+                accessibilityDescription: L10n.Settings.Accessibility.Title.menu
+            )!
+        ) {
+            Self()
+        }
+    }()
+}

--- a/BatFiKit/Sources/Settings/Settings.swift
+++ b/BatFiKit/Sources/Settings/Settings.swift
@@ -12,6 +12,7 @@ public final class SettingsController {
     private lazy var settingsWindowController = SettingsWindowController(
         panes: [
             GeneralView.pane,
+            MenuView.pane,
             ChargingView.pane,
             NotificationsView.pane
         ]

--- a/BatFiKit/Sources/Shared/Private.swift
+++ b/BatFiKit/Sources/Shared/Private.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public class Private {
+    public static let systemstats_get_top_coalitions = {
+        var systemstats_get_top_coalitionsPointer: UnsafeMutableRawPointer?
+        if let handle = dlopen("/usr/lib/libsystemstats.dylib", RTLD_LAZY) {
+            systemstats_get_top_coalitionsPointer = dlsym(handle, "systemstats_get_top_coalitions")
+            dlclose(handle)
+        }
+        let systemstats_get_top_coalitions =
+        unsafeBitCast(systemstats_get_top_coalitionsPointer, to: (@convention(c) (_ duration: Int, _ count: Int) -> Unmanaged<NSDictionary>)?.self)
+        return systemstats_get_top_coalitions
+    }()
+}


### PR DESCRIPTION
<details>
  <summary>Potentially interesting systemstats functions</summary>

```swift
func systemstats_get_top_coalitions(_ duration: Int , _ count: Int) -> Unmanaged<NSDictionary>
func systemstats_get_coalition_battery_breakdown(_ duration: Int , _ count: Int) -> Unmanaged<NSDictionary>
func systemstats_get_battery_charge_graph() -> Unmanaged<NSDictionary>
func systemstats_get_time_range_summary(_ startTime: NSDate, _ endTime: NSDate) -> Unmanaged<NSDictionary>
```
</details>