### PR TITLE
fix typo in german localization

### DIFF
--- a/BatFiKit/Sources/L10n/Localizable.xcstrings
+++ b/BatFiKit/Sources/L10n/Localizable.xcstrings
@@ -8853,7 +8853,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Das Aufladen automatisch passieren, wenn der Mac in den Ruhezustand wechselt"
+            "value" : "Das Aufladen automatisch pausieren, wenn der Mac in den Ruhezustand wechselt"
           }
         },
         "en" : {


### PR DESCRIPTION
Hi there,

i just fixed a little typo in the german localization: "passieren" -> "pausieren".

best,
adam